### PR TITLE
Fixes for compiling this shell on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 NAME = minishell
 
 CC		= cc
-CFLAGS	= -Wall -Wextra -Werror
+CFLAGS	= -Wall -Wextra -Werror -I .
 AR		= ar rcs
 RM		= @rm -f
 HEADER	= push_swap.h
@@ -34,14 +34,14 @@ SRCS = $(addprefix $(SRCS_DIR), $(addsuffix .c, $(FILES)))
 OBJS_DIR = ./
 OBJS = $(addprefix $(OBJS_DIR), $(addsuffix .o, $(FILES)))
 
-%.o:%.c $(HEADER)
+%.o:%.c
 	@echo "$(YELLOW)Compiling: $< $(DEF_COLOR)"
-	@$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) -c $< $(CFLAGS) -o $@ -L libft -l ft
 
 $(NAME): $(OBJS)
 	@make -C libft
 	@echo "$(GREEN)😳😎minishell compiled!😎😳$(DEF_COLOR)"
-	@${CC} libft/libft.a ${FLAGS} ${SRCS} -o ${NAME}
+	${CC} ${FLAGS} ${OBJS} main.c -o ${NAME} -L libft -l ft
 
 
 clean:

--- a/libft/ft_memchr.c
+++ b/libft/ft_memchr.c
@@ -15,12 +15,13 @@
 void	*ft_memchr(const void *s, int c, size_t n)
 {
 	size_t	i;
-
+	const unsigned char *s_cast = (const unsigned char*)s;
+	
 	i = 0;
 	while (i < n)
 	{
-		if (((unsigned char *)s)[i] == (unsigned char)c)
-			return (&((void *)s)[i]);
+		if (s_cast[i] == (unsigned char)c)
+			return (void*)&s_cast[i];
 		i++;
 	}
 	return (0);

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -15,6 +15,7 @@
 
 # include <unistd.h>
 # include <stdlib.h>
+#include <stdint.h>
 
 void		*ft_memset(void *str, int c, size_t n);
 void		ft_bzero(void *str, size_t n);

--- a/main.c
+++ b/main.c
@@ -16,6 +16,8 @@
 #include <string.h>
 #include <sys/wait.h>
 #include <errno.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #define MAX_LINE_LENGTH 256
 

--- a/parsing/command_parsing.c
+++ b/parsing/command_parsing.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../minishell.h"
+#include "minishell.h"
 
 // DECOMPOSITION = "command" + "-flag" + "arguments"
 


### PR DESCRIPTION
**_Why this fork ?_** 
Well, I couldn't compile this project mainly because of the **"-Werror"** flag passed to GCC that caused it to abort the compilation if one error occurs.

**_What changes did I make ?_**
Nothing regarding the core of the project but rather what was **necessary** for this project to be compiled on _Linux_. I also fixed some other warnings like _implicitly declared variables_ and the way the header file "minishell.h" was included.

Also, the _makefile_ was not right as it wasn't including the _libft_ library and so they were undefined functions. But now all of this is fixed.

Please let me know if you have some questions regarding my changes